### PR TITLE
Fix path issue when Dokuwiki not in root directory

### DIFF
--- a/style.css
+++ b/style.css
@@ -12,15 +12,15 @@
  * to specify the style for the list item mark
  */
 .acmenu ul.idx li.closed {
-    list-style-image: url(/lib/images/closed.png);
+    list-style-image: url(../../images/closed.png);
 }
 
 .acmenu ul.idx li.open {
-    list-style-image: url(/lib/images/open.png);
+    list-style-image: url(../../images/open.png);
 }
 
 .acmenu ul.idx li {
-    list-style-image: url(/lib/images/bullet.png);
+    list-style-image: url(../../images/bullet.png);
 }
 
 .acmenu ul.idx {


### PR DESCRIPTION
This is a fix for issue #6 that occurs when DokuWiki is not installed in the root directory. In this case, the images used to designate open/closed directories, and the bullets in front of pages, are not rendered because the path is invalid. Replacing the absolute path to the images with relative paths solves the problem - both, and works regardless of whether DokuWiki is installed in the root directory or not.