### PR TITLE
Fixes #10

### DIFF
--- a/script.js
+++ b/script.js
@@ -190,6 +190,5 @@ jQuery(document).ready(function() {
         }
         var cookie_value = JSON.stringify(_OPEN_ITEMS);
         document.cookie = _COOKIE_NAME + "=" + cookie_value + ";expires='';path=/";
-        if (event.target.nodeName !== "A") event.preventDefault();
     });
 });

--- a/script.js
+++ b/script.js
@@ -84,6 +84,55 @@ function trim_url(url) {
     return trimmed_url;
 }
 
+/*
+	jQuery-GetPath v0.01, by Dave Cardwell. (2007-04-27)
+	
+	http://davecardwell.co.uk/javascript/jquery/plugins/jquery-getpath/
+	
+	Copyright (c)2007 Dave Cardwell. All rights reserved.
+	Released under the MIT License.
+	
+	
+	Usage:
+	var path = $('#foo').getPath();
+*/
+
+// https://stackoverflow.com/a/26763360
+jQuery.fn.extend({
+    getPath: function() {
+        var pathes = [];
+
+        this.each(function(index, element) {
+            var path, $node = jQuery(element);
+
+            while ($node.length) {
+                var realNode = $node.get(0), name = realNode.localName;
+                if (!name) { break; }
+
+                name = name.toLowerCase();
+                var parent = $node.parent();
+                var sameTagSiblings = parent.children(name);
+
+                if (sameTagSiblings.length > 1)
+                {
+                    allSiblings = parent.children();
+                    var index = allSiblings.index(realNode) +1;
+                    if (index > 0) {
+                        name += ':nth-child(' + index + ')';
+                    }
+                }
+
+                path = name + (path ? ' > ' + path : '');
+                $node = parent;
+            }
+
+            pathes.push(path);
+        });
+
+        return pathes.join(',');
+    }
+});
+
 jQuery(document).ready(function() {
     // Example of a nested menu:
     // ns 0  // open item
@@ -123,21 +172,24 @@ jQuery(document).ready(function() {
 
     jQuery(selector).click(function(event) {
         event.stopPropagation();
-        if (event.target.nodeName === "LI") {
-            var item = trim_url(jQuery(this).find("a").attr("href"));
-            event.preventDefault();
-            if (jQuery(this).find("ul.idx:first").is(":hidden")) {
-                jQuery(this).find("ul.idx:first").slideDown("fast");
-                jQuery(this).removeClass("closed").addClass("open");
-                _OPEN_ITEMS.push(item);
-            }
-            else {
-                jQuery(this).find("ul.idx:first").slideUp("fast");
-                jQuery(this).removeClass("open").addClass("closed");
-                _OPEN_ITEMS.splice(jQuery.inArray(item, _OPEN_ITEMS), 1);
-            }
-            var cookie_value = JSON.stringify(_OPEN_ITEMS);
-            document.cookie = _COOKIE_NAME + "=" + cookie_value + ";expires='';path=/";
+        
+        var elementPath = jQuery(this).getPath();
+        if (event.target.nodeName === "UL") elementPath = elementPath + ' > ul > li:nth-child(1)';
+        // alert(elementPath + " (" + event.target.nodeName + " - " + jQuery(elementPath + ' > ul').length + ")");
+        
+        var item = trim_url(jQuery(elementPath + ' > div > a').attr('href'));
+        if ((event.target.nodeName === "A") || jQuery(elementPath + ' > ul').is(":hidden")) {
+            jQuery(elementPath + ' > ul').slideDown("fast");
+            jQuery(elementPath).removeClass("closed").addClass("open");
+            _OPEN_ITEMS.push(item);
         }
+        else {
+            jQuery(elementPath + ' > ul').slideUp("fast");
+            jQuery(elementPath).removeClass("open").addClass("closed");
+            _OPEN_ITEMS.splice(jQuery.inArray(item, _OPEN_ITEMS), 1);
+        }
+        var cookie_value = JSON.stringify(_OPEN_ITEMS);
+        document.cookie = _COOKIE_NAME + "=" + cookie_value + ";expires='';path=/";
+        if (event.target.nodeName !== "A") event.preventDefault();
     });
 });

--- a/script.js
+++ b/script.js
@@ -116,27 +116,28 @@ jQuery(document).ready(function() {
     //     </ul>
     // </div>
 
-    const selector = "div.acmenu ul.idx > li:not([class^='level']) > div.li";
+    const selector = "div.acmenu ul.idx > li:not([class^='level'])";
 
     get_cookie();
     set_cookie();
 
     jQuery(selector).click(function(event) {
-        var item = trim_url(jQuery(this).find("a").attr("href"));
-        event.preventDefault();
-        if (jQuery(this).next().is(":hidden")) {
-            jQuery(this)
-            .next().slideDown("fast")
-            .parent().removeClass("closed").addClass("open");
-            _OPEN_ITEMS.push(item);
+        event.stopPropagation();
+        if (event.target.nodeName === "LI") {
+            var item = trim_url(jQuery(this).find("a").attr("href"));
+            event.preventDefault();
+            if (jQuery(this).find("ul.idx:first").is(":hidden")) {
+                jQuery(this).find("ul.idx:first").slideDown("fast");
+                jQuery(this).removeClass("closed").addClass("open");
+                _OPEN_ITEMS.push(item);
+            }
+            else {
+                jQuery(this).find("ul.idx:first").slideUp("fast");
+                jQuery(this).removeClass("open").addClass("closed");
+                _OPEN_ITEMS.splice(jQuery.inArray(item, _OPEN_ITEMS), 1);
+            }
+            var cookie_value = JSON.stringify(_OPEN_ITEMS);
+            document.cookie = _COOKIE_NAME + "=" + cookie_value + ";expires='';path=/";
         }
-        else {
-            jQuery(this)
-            .next().slideUp("fast")
-            .parent().removeClass("open").addClass("closed");
-            _OPEN_ITEMS.splice(jQuery.inArray(item, _OPEN_ITEMS), 1);
-        }
-        var cookie_value = JSON.stringify(_OPEN_ITEMS);
-        document.cookie = _COOKIE_NAME + "=" + cookie_value + ";expires='';path=/";
     });
 });

--- a/style.css
+++ b/style.css
@@ -13,6 +13,7 @@
  */
 .acmenu ul.idx li {
     display: list-item;
+    cursor: pointer;
 }
  
 .acmenu ul.idx li.closed {

--- a/style.css
+++ b/style.css
@@ -11,6 +11,10 @@
 /* for template different from the DokuWiki's default one is necessary
  * to specify the style for the list item mark
  */
+.acmenu ul.idx li {
+    display: list-item;
+}
+ 
 .acmenu ul.idx li.closed {
     list-style-image: url(../../images/closed.png);
 }

--- a/syntax.php
+++ b/syntax.php
@@ -138,7 +138,7 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
         $open_items = $this->_get_cookie();
         // print the namespace tree structure
         $renderer->doc .= "<div class='acmenu'>";
-        if (!preg_match("/" . $conf["hidepages"] . "/ui", ':' . $base_id)) {
+        if (!isHiddenPage($base_id)) {
             $renderer->doc .= "<ul class='idx'>";
             $renderer->doc .= "<li class='open'>";
             $renderer->doc .= "<div class='li'>";
@@ -150,7 +150,7 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
         $renderer->doc .= "<ul class='idx'>";
         $this->_print($renderer, $tree, $sub_ns, $open_items);
         $renderer->doc .= "</ul>";
-        if (!preg_match("/" . $conf["hidepages"] . "/ui", ':' . $base_id)) {
+        if (!isHiddenPage($base_id)) {
             $renderer->doc .= "</li>";
             $renderer->doc .= "</ul>";
         }
@@ -403,7 +403,8 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
                 }
             } elseif ($val["type"] == "ns") {
                 if (in_array(substr($val["id"], 0, -strlen(":" . $conf["start"])), $sub_ns)
-                    || in_array($val["id"], $open_items)) {
+                    || in_array($val["id"], $open_items) 
+                    || in_array(substr($val["id"], 0, -strlen(":" . $conf["start"])), $open_items)) {
                     $renderer->doc .= "<li class='open'>";
                 } else {
                     $renderer->doc .= "<li class='closed'>";
@@ -414,7 +415,7 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
                     $renderer->internallink($val["id"], $val["heading"]);
                     $renderer->doc .= "</span>";
                 } else {
-                    if (@file_exists(wikiFN($val["id"] . ":" . $conf["start"]))) {
+                    if (page_exists(wikiFN($val["id"] . ":" . $conf["start"]))) {
                         $renderer->internallink($val["id"], $val["heading"]);
                     } else {
                         $renderer->internallink(substr($val["id"], 0, -strlen(":" . $conf["start"])), $val["heading"]);
@@ -422,7 +423,8 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
                 }
                 $renderer->doc .= "</div>";
                 if (in_array(substr($val["id"], 0, -strlen(":" . $conf["start"])), $sub_ns)
-                    || in_array($val["id"], $open_items)) {
+                    || in_array($val["id"], $open_items)
+                    || in_array(substr($val["id"], 0, -strlen(":" . $conf["start"])), $open_items)) {
                     $renderer->doc .= "<ul class='idx'>";
                 } else {
                     $renderer->doc .= "<ul class='idx' style='display: none'>";

--- a/syntax.php
+++ b/syntax.php
@@ -138,22 +138,18 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
         $open_items = $this->_get_cookie();
         // print the namespace tree structure
         $renderer->doc .= "<div class='acmenu'>";
-        if (!isHiddenPage($base_id)) {
-            $renderer->doc .= "<ul class='idx'>";
-            $renderer->doc .= "<li class='open'>";
-            $renderer->doc .= "<div class='li'>";
-            $renderer->doc .= "<span class='curid'>";
-            $renderer->internallink($base_id, $base_heading);
-            $renderer->doc .= "</span>";
-            $renderer->doc .= "</div>";
-        }
+        $renderer->doc .= "<ul class='idx'>";
+        $renderer->doc .= "<li class='open'>";
+        $renderer->doc .= "<div class='li'>";
+        $renderer->doc .= "<span class='curid'>";
+        $renderer->internallink($base_id, $base_heading);
+        $renderer->doc .= "</span>";
+        $renderer->doc .= "</div>";
         $renderer->doc .= "<ul class='idx'>";
         $this->_print($renderer, $tree, $sub_ns, $open_items);
         $renderer->doc .= "</ul>";
-        if (!isHiddenPage($base_id)) {
-            $renderer->doc .= "</li>";
-            $renderer->doc .= "</ul>";
-        }
+        $renderer->doc .= "</li>";
+        $renderer->doc .= "</ul>";
         $renderer->doc .= "</div>";
         // only if javascript is enabled and only at the first time
         // hide the content of each namespace

--- a/syntax.php
+++ b/syntax.php
@@ -136,21 +136,24 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
 
         // get cookies
         $open_items = $this->_get_cookie();
-
         // print the namespace tree structure
         $renderer->doc .= "<div class='acmenu'>";
-        $renderer->doc .= "<ul class='idx'>";
-        $renderer->doc .= "<li class='open'>";
-        $renderer->doc .= "<div class='li'>";
-        $renderer->doc .= "<span class='curid'>";
-        $renderer->internallink($base_id, $base_heading);
-        $renderer->doc .= "</span>";
-        $renderer->doc .= "</div>";
+        if (!preg_match("/" . $conf["hidepages"] . "/ui", ':' . $base_id)) {
+            $renderer->doc .= "<ul class='idx'>";
+            $renderer->doc .= "<li class='open'>";
+            $renderer->doc .= "<div class='li'>";
+            $renderer->doc .= "<span class='curid'>";
+            $renderer->internallink($base_id, $base_heading);
+            $renderer->doc .= "</span>";
+            $renderer->doc .= "</div>";
+        }
         $renderer->doc .= "<ul class='idx'>";
         $this->_print($renderer, $tree, $sub_ns, $open_items);
         $renderer->doc .= "</ul>";
-        $renderer->doc .= "</li>";
-        $renderer->doc .= "</ul>";
+        if (!preg_match("/" . $conf["hidepages"] . "/ui", ':' . $base_id)) {
+            $renderer->doc .= "</li>";
+            $renderer->doc .= "</ul>";
+        }
         $renderer->doc .= "</div>";
         // only if javascript is enabled and only at the first time
         // hide the content of each namespace
@@ -391,11 +394,13 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
         global $conf;
         foreach ($tree as $key => $val) {
             if ($val["type"] == "pg") {
-                $renderer->doc .= "<li class='level" . $val["level"]."'>";
-                $renderer->doc .= "<div class='li'>";
-                $renderer->internallink($val["id"], $val["heading"]);
-                $renderer->doc .= "</div>";
-                $renderer->doc .= "</li>";
+                if (!@is_dir(substr(wikiFN($val["id"]), 0, -strlen(".txt")))) {
+                    $renderer->doc .= "<li class='level" . $val["level"]."'>";
+                    $renderer->doc .= "<div class='li'>";
+                    $renderer->internallink($val["id"], $val["heading"]);
+                    $renderer->doc .= "</div>";
+                    $renderer->doc .= "</li>";
+                }
             } elseif ($val["type"] == "ns") {
                 if (in_array(substr($val["id"], 0, -strlen(":" . $conf["start"])), $sub_ns)
                     || in_array($val["id"], $open_items)) {
@@ -409,7 +414,11 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
                     $renderer->internallink($val["id"], $val["heading"]);
                     $renderer->doc .= "</span>";
                 } else {
-                    $renderer->internallink($val["id"], $val["heading"]);
+                    if (@file_exists(wikiFN($val["id"] . ":" . $conf["start"]))) {
+                        $renderer->internallink($val["id"], $val["heading"]);
+                    } else {
+                        $renderer->internallink(substr($val["id"], 0, -strlen(":" . $conf["start"])), $val["heading"]);
+                    }
                 }
                 $renderer->doc .= "</div>";
                 if (in_array(substr($val["id"], 0, -strlen(":" . $conf["start"])), $sub_ns)


### PR DESCRIPTION
Not sure if you will accept this PR, because it implements some major changes into the  way the plug-in works, but there's some suggestions that worth checking and can be applied even if you didn't accept this PR. If you think that those changes are too much, we can find a way to make them optional, maybe adding an option to enable those features at the DokuWiki Settings.

Here's the way the plugin is working now (as stated in https://github.com/my17560/dokuwiki-template-readthedokus/issues/32):

![Animação](https://user-images.githubusercontent.com/2974895/216579378-4f5aa2a9-474b-4cc4-b9fe-9e487b526c51.gif)

I'll start with changes that I recommend implementing:

1. CSS changes: There's just two lines changed at the CSS file. It adds a cursor icon at the li icon to make it intuitive to the end user that it's clickable. Other change that I made was adding the "list-item" style for the AcMenu list, because some templates like "Read the Dokus" and "Argon Alternative" does a normalization removing all inherit styles from HTML, so your plugin didn't show the list icons in those templates. I recommend you apply those changes at your CSS file, too.

Now the harder to explain ones: I took about ~8 hours to figure out how your plugin works and how I could implement the feature I wanted (I'm not exactly a Dev and it was the first time I was working with Cookies - was funny to figure out through the "Applications" tab of Dev Tools from Chrome how you implemented the browsing feature). Basically, I'm migrating from IndexMenu to your plug-in because IndexMenu seems a lot instable to me at PHP 8.1 (as can be seen here: https://github.com/samuelet/indexmenu/pull/261).

The major change I was talking about is the way that pages and namespace are handled. Now they are together, instead of showing namespace first followed by the pages (as reported in #10). So now for the user to browse through the namespace, he/she must use the li icon, otherwise it will open the page that it contains. This behaviour is the same of simpleNavi and IndexMenu plugins.

I also edited your source code to respect the ``hidepages`` DokuWiki directive, so if an admin wanted to hide pages, it will not be shown at the AcMenu.