### PR TITLE
Fix useheading sorting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # ignore these directories and their content
 .vscode
+.DS_Store

--- a/action.php
+++ b/action.php
@@ -45,6 +45,7 @@ class action_plugin_acmenu extends DokuWiki_Action_Plugin
         $JSINFO["plugin_acmenu"]["useslash"] = $conf["useslash"];
         $JSINFO["plugin_acmenu"]["canonical"] = $conf["canonical"];
         $JSINFO["plugin_acmenu"]["userewrite"] = $conf["userewrite"];
+        $JSINFO["plugin_acmenu"]["mergenspg"] = $this->getConf("mergenspg");
         // namespace genealogy doesn't exist for an id deleated
         if(isset($INFO["meta"]["plugin"]["plugin_acmenu"]["sub_ns"])) {
             $JSINFO["plugin_acmenu"]["sub_ns"] = $INFO["meta"]["plugin"]["plugin_acmenu"]["sub_ns"];

--- a/action.php
+++ b/action.php
@@ -46,7 +46,7 @@ class action_plugin_acmenu extends DokuWiki_Action_Plugin
         $JSINFO["plugin_acmenu"]["canonical"] = $conf["canonical"];
         $JSINFO["plugin_acmenu"]["userewrite"] = $conf["userewrite"];
         $JSINFO["plugin_acmenu"]["mergenspg"] = $this->getConf("mergenspg");
-        // namespace genealogy doesn't exist for an id deleated
+        // namespace genealogy doesn't exist for an id deleted
         if(isset($INFO["meta"]["plugin"]["plugin_acmenu"]["sub_ns"])) {
             $JSINFO["plugin_acmenu"]["sub_ns"] = $INFO["meta"]["plugin"]["plugin_acmenu"]["sub_ns"];
         }

--- a/conf/default.php
+++ b/conf/default.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * Default settings for the caption plugin
+ *
+ * @author Torpedo <dcstoyanov@gmail.com>
+ */
+
+//$conf['fixme']    = 'FIXME';
+$conf['mergenspg'] = '';

--- a/conf/default.php
+++ b/conf/default.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Default settings for the caption plugin
+ * Options for the acmenu plugin
  *
- * @author Torpedo <dcstoyanov@gmail.com>
+ * @author Till Biskup <till@till-biskup.de>
  */
 
 //$conf['fixme']    = 'FIXME';

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Options for the caption plugin
+ * Options for the acmenu plugin
  *
  * @author Till Biskup <till@till-biskup.de>
  */

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Options for the caption plugin
+ *
+ * @author Till Biskup <till@till-biskup.de>
+ */
+
+
+//$meta['fixme'] = array('string');
+$meta['mergenspg'] = array('onoff');
+

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * english language file for acmenu plugin
+ *
+ * @author Torpedo <dcstoyanov@gmail.com>
+ */
+
+// keys need to match the config setting name
+$lang['mergenspg'] = 'Merge pages and namespace?';
+
+
+
+//Setup VIM: ex: et ts=4 :

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -6,7 +6,7 @@
  */
 
 // keys need to match the config setting name
-$lang['mergenspg'] = 'Merge pages and namespace?';
+$lang['mergenspg'] = 'Merge Namespace & Start Page?';
 
 
 

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -2,7 +2,7 @@
 /**
  * english language file for acmenu plugin
  *
- * @author Torpedo <dcstoyanov@gmail.com>
+ * @author Till Biskup <till@till-biskup.de>
  */
 
 // keys need to match the config setting name

--- a/lang/pt-br/settings.php
+++ b/lang/pt-br/settings.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Language file for caption plugin
+ *
+ * @author Eduardo Mozart de Oliveira <eduardomozart182@gmail.com>
+ */
+
+// keys need to match the config setting name
+// $lang['fixme'] = 'FIXME';
+$lang['abbrev'] = 'Mesclar páginas e espaço de nomes?';
+
+
+
+//Setup VIM: ex: et ts=4 :

--- a/lang/pt-br/settings.php
+++ b/lang/pt-br/settings.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Language file for caption plugin
+ * Language file for acmenu plugin
  *
  * @author Eduardo Mozart de Oliveira <eduardomozart182@gmail.com>
  */

--- a/lang/pt-br/settings.php
+++ b/lang/pt-br/settings.php
@@ -7,7 +7,7 @@
 
 // keys need to match the config setting name
 // $lang['fixme'] = 'FIXME';
-$lang['abbrev'] = 'Mesclar páginas e espaço de nomes?';
+$lang['abbrev'] = 'Mesclar espaço de nomes e página inicial?';
 
 
 

--- a/lang/pt-br/settings.php
+++ b/lang/pt-br/settings.php
@@ -7,7 +7,7 @@
 
 // keys need to match the config setting name
 // $lang['fixme'] = 'FIXME';
-$lang['abbrev'] = 'Mesclar espaço de nomes e página inicial?';
+$lang['mergenspg'] = 'Mesclar espaço de nomes e página inicial?';
 
 
 

--- a/script.js
+++ b/script.js
@@ -176,10 +176,10 @@ jQuery(document).ready(function() {
 
         var elementPath = jQuery(this).getPath();
         if (event.target.nodeName === "UL") elementPath = elementPath + ' > ul > li:nth-child(1)';
-        // alert(elementPath + " (" + event.target.nodeName + " - " + jQuery(elementPath + ' > ul').length + ")");
+        // console.log(elementPath + " (" + event.target.nodeName + " - " + jQuery(elementPath + ' > ul').length + ")");
 
-        var item = trim_url(jQuery(elementPath + ' > div > a').attr('href'));
-        if ((event.target.nodeName === "A") || jQuery(elementPath + ' > ul').is(":hidden")) {
+        var item = trim_url(jQuery(elementPath + ' > div a').first().attr('href'));
+        if ((event.target.nodeName === "DIV") && jQuery(elementPath + ' > ul').is(":hidden")) {
             jQuery(elementPath + ' > ul').slideDown("fast");
             jQuery(elementPath).removeClass("closed").addClass("open");
             _OPEN_ITEMS.push(item);

--- a/script.js
+++ b/script.js
@@ -117,7 +117,7 @@ jQuery(document).ready(function() {
     //     </ul>
     // </div>
 
-    const selector = "div.acmenu ul.idx > li:not([class^='level'])";
+    const selector = "div.acmenu ul.idx > li:not([class^='level']) > div.li";
 
     get_cookie();
     set_cookie();

--- a/script.js
+++ b/script.js
@@ -85,55 +85,6 @@ function trim_url(url) {
     return trimmed_url;
 }
 
-/*
-	jQuery-GetPath v0.01, by Dave Cardwell. (2007-04-27)
-	
-	http://davecardwell.co.uk/javascript/jquery/plugins/jquery-getpath/
-	
-	Copyright (c)2007 Dave Cardwell. All rights reserved.
-	Released under the MIT License.
-	
-	
-	Usage:
-	var path = $('#foo').getPath();
-*/
-
-// https://stackoverflow.com/a/26763360
-jQuery.fn.extend({
-    getPath: function() {
-        var pathes = [];
-
-        this.each(function(index, element) {
-            var path, $node = jQuery(element);
-
-            while ($node.length) {
-                var realNode = $node.get(0), name = realNode.localName;
-                if (!name) { break; }
-
-                name = name.toLowerCase();
-                var parent = $node.parent();
-                var sameTagSiblings = parent.children(name);
-
-                if (sameTagSiblings.length > 1)
-                {
-                    allSiblings = parent.children();
-                    var index = allSiblings.index(realNode) +1;
-                    if (index > 0) {
-                        name += ':nth-child(' + index + ')';
-                    }
-                }
-
-                path = name + (path ? ' > ' + path : '');
-                $node = parent;
-            }
-
-            pathes.push(path);
-        });
-
-        return pathes.join(',');
-    }
-});
-
 jQuery(document).ready(function() {
     // Example of a nested menu:
     // ns 0  // open item
@@ -172,21 +123,24 @@ jQuery(document).ready(function() {
     set_cookie();
 
     jQuery(selector).click(function(event) {
-        event.stopPropagation();
-
-        var elementPath = jQuery(this).getPath();
-        if (event.target.nodeName === "UL") elementPath = elementPath + ' > ul > li:nth-child(1)';
-        // alert(elementPath + " (" + event.target.nodeName + " - " + jQuery(elementPath + ' > ul').length + ")");
-
-        var item = trim_url(jQuery(elementPath + ' > div > a').attr('href'));
-        if ((event.target.nodeName === "A") || jQuery(elementPath + ' > ul').is(":hidden")) {
-            jQuery(elementPath + ' > ul').slideDown("fast");
-            jQuery(elementPath).removeClass("closed").addClass("open");
+        var item = trim_url(jQuery(this).find("a").attr("href"));
+        if (JSINFO.plugin_acmenu.mergenspg) {
+            event.stopPropagation();
+        } else {
+            event.preventDefault();
+        }
+        if (jQuery(this).next().is(":hidden")) {
+            if (!JSINFO.plugin_acmenu.mergenspg || JSINFO.plugin_acmenu.mergenspg && (event.target.nodeName === "DIV")) {
+                jQuery(this)
+                .next().slideDown("fast")
+                .parent().removeClass("closed").addClass("open");
+            }
             _OPEN_ITEMS.push(item);
         }
         else {
-            jQuery(elementPath + ' > ul').slideUp("fast");
-            jQuery(elementPath).removeClass("open").addClass("closed");
+            jQuery(this)
+            .next().slideUp("fast")
+            .parent().removeClass("open").addClass("closed");
             _OPEN_ITEMS.splice(jQuery.inArray(item, _OPEN_ITEMS), 1);
         }
         var cookie_value = JSON.stringify(_OPEN_ITEMS);

--- a/script.js
+++ b/script.js
@@ -85,6 +85,55 @@ function trim_url(url) {
     return trimmed_url;
 }
 
+/*
+	jQuery-GetPath v0.01, by Dave Cardwell. (2007-04-27)
+	
+	http://davecardwell.co.uk/javascript/jquery/plugins/jquery-getpath/
+	
+	Copyright (c)2007 Dave Cardwell. All rights reserved.
+	Released under the MIT License.
+	
+	
+	Usage:
+	var path = $('#foo').getPath();
+*/
+
+// https://stackoverflow.com/a/26763360
+jQuery.fn.extend({
+    getPath: function() {
+        var pathes = [];
+
+        this.each(function(index, element) {
+            var path, $node = jQuery(element);
+
+            while ($node.length) {
+                var realNode = $node.get(0), name = realNode.localName;
+                if (!name) { break; }
+
+                name = name.toLowerCase();
+                var parent = $node.parent();
+                var sameTagSiblings = parent.children(name);
+
+                if (sameTagSiblings.length > 1)
+                {
+                    allSiblings = parent.children();
+                    var index = allSiblings.index(realNode) +1;
+                    if (index > 0) {
+                        name += ':nth-child(' + index + ')';
+                    }
+                }
+
+                path = name + (path ? ' > ' + path : '');
+                $node = parent;
+            }
+
+            pathes.push(path);
+        });
+
+        return pathes.join(',');
+    }
+});
+
 jQuery(document).ready(function() {
     // Example of a nested menu:
     // ns 0  // open item
@@ -117,24 +166,27 @@ jQuery(document).ready(function() {
     //     </ul>
     // </div>
 
-    const selector = "div.acmenu ul.idx > li:not([class^='level']) > div.li";
+    const selector = "div.acmenu ul.idx > li:not([class^='level'])";
 
     get_cookie();
     set_cookie();
 
     jQuery(selector).click(function(event) {
-        var item = trim_url(jQuery(this).find("a").attr("href"));
-        event.preventDefault();
-        if (jQuery(this).next().is(":hidden")) {
-            jQuery(this)
-            .next().slideDown("fast")
-            .parent().removeClass("closed").addClass("open");
+        event.stopPropagation();
+
+        var elementPath = jQuery(this).getPath();
+        if (event.target.nodeName === "UL") elementPath = elementPath + ' > ul > li:nth-child(1)';
+        // alert(elementPath + " (" + event.target.nodeName + " - " + jQuery(elementPath + ' > ul').length + ")");
+
+        var item = trim_url(jQuery(elementPath + ' > div > a').attr('href'));
+        if ((event.target.nodeName === "A") || jQuery(elementPath + ' > ul').is(":hidden")) {
+            jQuery(elementPath + ' > ul').slideDown("fast");
+            jQuery(elementPath).removeClass("closed").addClass("open");
             _OPEN_ITEMS.push(item);
         }
         else {
-            jQuery(this)
-            .next().slideUp("fast")
-            .parent().removeClass("open").addClass("closed");
+            jQuery(elementPath + ' > ul').slideUp("fast");
+            jQuery(elementPath).removeClass("open").addClass("closed");
             _OPEN_ITEMS.splice(jQuery.inArray(item, _OPEN_ITEMS), 1);
         }
         var cookie_value = JSON.stringify(_OPEN_ITEMS);

--- a/script.js
+++ b/script.js
@@ -138,9 +138,11 @@ jQuery(document).ready(function() {
             _OPEN_ITEMS.push(item);
         }
         else {
-            jQuery(this)
-            .next().slideUp("fast")
-            .parent().removeClass("open").addClass("closed");
+            if (!JSINFO.plugin_acmenu.mergenspg || JSINFO.plugin_acmenu.mergenspg && (event.target.nodeName === "DIV")) {
+                jQuery(this)
+                .next().slideUp("fast")
+                .parent().removeClass("open").addClass("closed");
+            }
             _OPEN_ITEMS.splice(jQuery.inArray(item, _OPEN_ITEMS), 1);
         }
         var cookie_value = JSON.stringify(_OPEN_ITEMS);

--- a/script.js
+++ b/script.js
@@ -143,10 +143,18 @@ jQuery(document).ready(function() {
                            JSINFO.plugin_acmenu.mergenspg === "on"
                            );
 
-        var is_link_click = jQuery(event.target).closest("a").length > 0;
+        var is_link_click = false;
+        var node = event.target;
+        while (node && node !== this) {
+            if (node.tagName && node.tagName.toUpperCase() === "A") {
+                is_link_click = true;
+                break;
+            }
+            node = node.parentNode;
+        }
 
         if (is_link_click && is_mergenspg) {
-            return; // Let the browser navigate
+            return; // Let the browser navigate naturally
         }
 
         event.preventDefault(); // Stop navigation if clicking text and mergenspg is false

--- a/script.js
+++ b/script.js
@@ -75,7 +75,7 @@ function trim_url(url) {
         xlink += JSINFO["plugin_acmenu"]["doku_script"] + "?id=";
     }
 
-    var trimmed_url = url.replace(xlink, "");  // return only page's id
+    var trimmed_url = decodeURIComponent(url.replace(xlink, ""));  // return only page's id
 
     if (JSINFO["plugin_acmenu"]["useslash"] == 1) {
         const slash = /\//g;

--- a/script.js
+++ b/script.js
@@ -132,8 +132,17 @@ jQuery(document).ready(function() {
         }
 
         var $a = jQuery(this).children("div.li").find("a");
-        if ($a.length === 0) return;
-        var item = trim_url($a.attr("href"));
+        var item = "";
+        if ($a.length > 0) {
+            item = trim_url($a.attr("href"));
+        } else {
+            var $span = jQuery(this).children("div.li").find("span.ns_nolink");
+            if ($span.length > 0) {
+                item = $span.attr("data-id");
+            } else {
+                return;
+            }
+        }
 
         var is_mergenspg = JSINFO.plugin_acmenu && (
                            JSINFO.plugin_acmenu.mergenspg === 1 || 

--- a/script.js
+++ b/script.js
@@ -133,16 +133,7 @@ jQuery(document).ready(function() {
 
         var $a = jQuery(this).children("div.li").find("a");
         var item = "";
-        if ($a.length > 0) {
-            item = trim_url($a.attr("href"));
-        } else {
-            var $span = jQuery(this).children("div.li").find("span.ns_nolink");
-            if ($span.length > 0) {
-                item = $span.attr("data-id");
-            } else {
-                return;
-            }
-        }
+        item = trim_url($a.attr("href"));
 
         var is_mergenspg = JSINFO.plugin_acmenu && (
                            JSINFO.plugin_acmenu.mergenspg === 1 || 

--- a/script.js
+++ b/script.js
@@ -133,7 +133,16 @@ jQuery(document).ready(function() {
 
         var $a = jQuery(this).children("div.li").find("a");
         var item = "";
-        item = trim_url($a.attr("href"));
+        if ($a.length > 0) {
+            item = trim_url($a.attr("href"));
+        } else {
+            var $span = jQuery(this).children("div.li").find("span.ns_nolink");
+            if ($span.length > 0) {
+                item = $span.attr("data-id");
+            } else {
+                return;
+            }
+        }
 
         var is_mergenspg = JSINFO.plugin_acmenu && (
                            JSINFO.plugin_acmenu.mergenspg === 1 || 

--- a/script.js
+++ b/script.js
@@ -117,33 +117,49 @@ jQuery(document).ready(function() {
     //     </ul>
     // </div>
 
-    const selector = "div.acmenu ul.idx > li:not([class^='level']) > div.li";
+    const selector = "div.acmenu ul.idx li:not([class^='level'])";
 
     get_cookie();
     set_cookie();
 
     jQuery(selector).click(function(event) {
-        var item = trim_url(jQuery(this).find("a").attr("href"));
-        if (JSINFO.plugin_acmenu.mergenspg) {
-            event.stopPropagation();
-        } else {
-            event.preventDefault();
+        event.stopPropagation(); // Prevent bubbling to parent namespaces
+        
+        var $submenu = jQuery(this).children("ul");
+        // Ignore clicks that originated from child pages (which bubbled up)
+        if ($submenu.length > 0 && jQuery.contains($submenu[0], event.target)) {
+            return;
         }
-        if (jQuery(this).next().is(":hidden")) {
-            if (!JSINFO.plugin_acmenu.mergenspg || JSINFO.plugin_acmenu.mergenspg && (event.target.nodeName === "DIV")) {
-                jQuery(this)
-                .next().slideDown("fast")
-                .parent().removeClass("closed").addClass("open");
+
+        var $a = jQuery(this).children("div.li").find("a");
+        if ($a.length === 0) return;
+        var item = trim_url($a.attr("href"));
+
+        var is_mergenspg = JSINFO.plugin_acmenu && (JSINFO.plugin_acmenu.mergenspg == 1 || JSINFO.plugin_acmenu.mergenspg == "1" || JSINFO.plugin_acmenu.mergenspg === true);
+        var is_link_click = (event.target.nodeName === "A" || (event.target.parentNode && event.target.parentNode.nodeName === "A"));
+
+        if (is_link_click && is_mergenspg) {
+            return; // Let the browser navigate
+        }
+
+        event.preventDefault(); // Stop navigation if clicking text and mergenspg is false
+
+        if ($submenu.length === 0) return;
+
+        if ($submenu.is(":hidden")) {
+            $submenu.slideDown("fast");
+            jQuery(this).removeClass("closed").addClass("open");
+            if (_OPEN_ITEMS.indexOf(item) === -1) {
+                _OPEN_ITEMS.push(item);
             }
-            _OPEN_ITEMS.push(item);
         }
         else {
-            if (!JSINFO.plugin_acmenu.mergenspg || JSINFO.plugin_acmenu.mergenspg && (event.target.nodeName === "DIV")) {
-                jQuery(this)
-                .next().slideUp("fast")
-                .parent().removeClass("open").addClass("closed");
+            $submenu.slideUp("fast");
+            jQuery(this).removeClass("open").addClass("closed");
+            var index = jQuery.inArray(item, _OPEN_ITEMS);
+            if (index !== -1) {
+                _OPEN_ITEMS.splice(index, 1);
             }
-            _OPEN_ITEMS.splice(jQuery.inArray(item, _OPEN_ITEMS), 1);
         }
         var cookie_value = JSON.stringify(_OPEN_ITEMS);
         document.cookie = _COOKIE_NAME + "=" + cookie_value + _COOKIE_PARAMETERS;

--- a/script.js
+++ b/script.js
@@ -126,8 +126,8 @@ jQuery(document).ready(function() {
         event.stopPropagation(); // Prevent bubbling to parent namespaces
         
         var $submenu = jQuery(this).children("ul");
-        // Ignore clicks that originated from child pages (which bubbled up)
-        if ($submenu.length > 0 && jQuery.contains($submenu[0], event.target)) {
+        // Ignore clicks that originated from child pages (which bubbled up) or clicking the ul padding itself
+        if ($submenu.length > 0 && ($submenu[0] === event.target || jQuery.contains($submenu[0], event.target))) {
             return;
         }
 
@@ -135,8 +135,15 @@ jQuery(document).ready(function() {
         if ($a.length === 0) return;
         var item = trim_url($a.attr("href"));
 
-        var is_mergenspg = JSINFO.plugin_acmenu && (JSINFO.plugin_acmenu.mergenspg == 1 || JSINFO.plugin_acmenu.mergenspg == "1" || JSINFO.plugin_acmenu.mergenspg === true);
-        var is_link_click = (event.target.nodeName === "A" || (event.target.parentNode && event.target.parentNode.nodeName === "A"));
+        var is_mergenspg = JSINFO.plugin_acmenu && (
+                           JSINFO.plugin_acmenu.mergenspg === 1 || 
+                           JSINFO.plugin_acmenu.mergenspg === "1" || 
+                           JSINFO.plugin_acmenu.mergenspg === true || 
+                           JSINFO.plugin_acmenu.mergenspg === "true" || 
+                           JSINFO.plugin_acmenu.mergenspg === "on"
+                           );
+
+        var is_link_click = jQuery(event.target).closest("a").length > 0;
 
         if (is_link_click && is_mergenspg) {
             return; // Let the browser navigate

--- a/script.js
+++ b/script.js
@@ -143,15 +143,7 @@ jQuery(document).ready(function() {
                            JSINFO.plugin_acmenu.mergenspg === "on"
                            );
 
-        var is_link_click = false;
-        var node = event.target;
-        while (node && node !== this) {
-            if (node.tagName && node.tagName.toUpperCase() === "A") {
-                is_link_click = true;
-                break;
-            }
-            node = node.parentNode;
-        }
+        var is_link_click = (event.target.nodeName === "A" || (event.target.parentNode && event.target.parentNode.nodeName === "A"));
 
         if (is_link_click && is_mergenspg) {
             return; // Let the browser navigate naturally

--- a/style.css
+++ b/style.css
@@ -11,11 +11,6 @@
 /* for template different from the DokuWiki's default one is necessary
  * to specify the style for the list item mark
  */
-.acmenu ul.idx li {
-    display: list-item;
-    cursor: pointer;
-}
-
 .acmenu ul.idx li.closed {
     list-style-image: url(../../images/closed.png);
 }

--- a/style.css
+++ b/style.css
@@ -11,6 +11,11 @@
 /* for template different from the DokuWiki's default one is necessary
  * to specify the style for the list item mark
  */
+.acmenu ul.idx li {
+    display: list-item;
+    cursor: pointer;
+}
+
 .acmenu ul.idx li.closed {
     list-style-image: url(../../images/closed.png);
 }

--- a/style.css
+++ b/style.css
@@ -23,6 +23,18 @@
     list-style-image: url(../../images/closed-rtl.png);
 }
 
+.acmenu span.ns_nolink {
+    cursor: pointer;
+    color: __link__;
+    text-decoration: none;
+}
+
+.acmenu span.ns_nolink:hover,
+.acmenu span.ns_nolink:active,
+.acmenu span.ns_nolink:focus {
+    text-decoration: underline;
+}
+
 .acmenu ul.idx li {
     list-style-image: url(../../images/bullet.png);
 }

--- a/syntax.php
+++ b/syntax.php
@@ -399,6 +399,9 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
                     $renderer->doc .= "</div>";
                     $renderer->doc .= "</li>";
             } elseif ($val["type"] == "ns") {
+                if (count($val["sub"]) == 0) {
+                    continue;
+                }
                 if (in_array(substr($val["id"], 0, -strlen(":" . $conf["start"])), $sub_ns)
                     || in_array($val["id"], $open_items)) {
                     $renderer->doc .= "<li class='open'>";

--- a/syntax.php
+++ b/syntax.php
@@ -278,9 +278,11 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
                 } else {
                     $heading = $file;
                     if (useheading("navigation")) {
-                        $heading = p_get_first_heading($id);
-                        if ($heading == NULL && substr($id, -strlen(":" . $conf["start"])) == ":" . $conf["start"]) {
-                            $heading = p_get_first_heading(substr($id, 0, -strlen(":" . $conf["start"])));
+                        if (page_exists($id)) {
+                            $heading = p_get_first_heading($id);
+                        } elseif (substr($id, -strlen(":" . $conf["start"])) == ":" . $conf["start"]) {
+                            $id = substr($id, 0, -strlen(":" . $conf["start"]));
+                            $heading = p_get_first_heading($id);
                         }
                     }
                     if (file_exists($dir . "/" . $file . "/" . $conf["sidebar"] . ".txt")) {
@@ -414,11 +416,7 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
                     $renderer->internallink($val["id"], $val["heading"]);
                     $renderer->doc .= "</span>";
                 } else {
-                    if (page_exists(wikiFN($val["id"] . ":" . $conf["start"]))) {
-                        $renderer->internallink($val["id"], $val["heading"]);
-                    } else {
-                        $renderer->internallink(substr($val["id"], 0, -strlen(":" . $conf["start"])), $val["heading"]);
-                    }
+                    $renderer->internallink($val["id"], $val["heading"]);
                 }
                 $renderer->doc .= "</div>";
                 if (in_array(substr($val["id"], 0, -strlen(":" . $conf["start"])), $sub_ns)

--- a/syntax.php
+++ b/syntax.php
@@ -404,13 +404,14 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
                 if (count($val["sub"]) == 0) {
                     continue;
                 }
-                if (in_array($val["id"], $open_items)) {
+                if (in_array($val["id"], $sub_ns)
+                    || in_array($val["id"], $open_items)) {
                     $renderer->doc .= "<li class='open'>";
                 } else {
                     $renderer->doc .= "<li class='closed'>";
                 }
                 $renderer->doc .= "<div class='li'>";
-                if (in_array(substr($val["id"], 0, -strlen(":" . $conf["start"])), $sub_ns)) {
+                if (in_array($val["id"], $sub_ns)) {
                     $renderer->doc .= "<span class='curid'>";
                     $renderer->internallink($val["id"], $val["heading"]);
                     $renderer->doc .= "</span>";
@@ -418,7 +419,8 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
                     $renderer->internallink($val["id"], $val["heading"]);
                 }
                 $renderer->doc .= "</div>";
-                if (in_array($val["id"], $open_items)) {
+                if (in_array($val["id"], $sub_ns)
+                    || in_array($val["id"], $open_items)) {
                     $renderer->doc .= "<ul class='idx'>";
                 } else {
                     $renderer->doc .= "<ul class='idx' style='display: none'>";

--- a/syntax.php
+++ b/syntax.php
@@ -385,7 +385,7 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
         global $conf;
         foreach ($tree as $key => $val) {
             if ($val["type"] == "pg") {
-                if (!@is_dir(substr(wikiFN($val["id"]), 0, -strlen(".txt")))) {
+                if ($this->getConf("mergenspg") && !@is_dir(substr(wikiFN($val["id"]), 0, -strlen(".txt")))) {
                     $renderer->doc .= "<li class='level" . $val["level"]."'>";
                     $renderer->doc .= "<div class='li'>";
                     $renderer->internallink($val["id"], $val["heading"]);

--- a/syntax.php
+++ b/syntax.php
@@ -404,8 +404,7 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
                 if (count($val["sub"]) == 0) {
                     continue;
                 }
-                if (in_array(substr($val["id"], 0, -strlen(":" . $conf["start"])), $sub_ns)
-                    || in_array($val["id"], $open_items)) {
+                if (in_array($val["id"], $open_items)) {
                     $renderer->doc .= "<li class='open'>";
                 } else {
                     $renderer->doc .= "<li class='closed'>";
@@ -419,8 +418,7 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
                     $renderer->internallink($val["id"], $val["heading"]);
                 }
                 $renderer->doc .= "</div>";
-                if (in_array(substr($val["id"], 0, -strlen(":" . $conf["start"])), $sub_ns)
-                    || in_array($val["id"], $open_items)) {
+                if (in_array($val["id"], $open_items)) {
                     $renderer->doc .= "<ul class='idx'>";
                 } else {
                     $renderer->doc .= "<ul class='idx' style='display: none'>";

--- a/syntax.php
+++ b/syntax.php
@@ -277,11 +277,11 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
                 $dir_id   = implode(":", array_filter(array($ns_acmenu, $file), "strlen"));
                 $start_id = implode(":", array_filter(array($ns_acmenu, $file, $conf["start"]), "strlen"));
                 if (page_exists($start_id)) {
-                    $id = $start_id;    // :acmenu:start exists → link to it
+                    $id = $start_id;  // :acmenu:start exists → link to it
                 } elseif (page_exists($dir_id)) {
-                    $id = $dir_id;      // :acmenu exists → link to it instead
+                    $id = $dir_id;    // :acmenu exists → link to it instead
                 } else {
-                    $id = "#ns_nolink"; // neither exists → render as anchor jump, no broken link
+                    $id = "";         // neither exists → render as plain text, no broken link
                 }
                 if ($conf["sneaky_index"] && auth_quickaclcheck($id) < AUTH_READ) {
                     continue;
@@ -396,20 +396,15 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
         foreach ($tree as $key => $val) {
             $val["id"] = utf8_decodeFN($val["id"]);
             $val["heading"] = utf8_decodeFN($val["heading"]);
-            if ($val["type"] == "pg") {
-                if (!$this->getConf("mergenspg") || ($val["id"] !== $parent_id && !@is_dir(substr(wikiFN($val["id"]), 0, -strlen(".txt"))))) {
-                    $renderer->doc .= "<li class='level" . $val["level"]."'>";
+            if ($val["type"] == "pg" || $val["type"] == "ext_ns") {
+                if ($val["type"] == "ext_ns" || !$this->getConf("mergenspg") || ($val["id"] !== $parent_id && !@is_dir(substr(wikiFN($val["id"]), 0, -strlen(".txt"))))) {
+                    $divert = ($val["type"] == "ext_ns") ? " divert" : "";
+                    $renderer->doc .= "<li class='level" . $val["level"] . $divert . "'>";
                     $renderer->doc .= "<div class='li'>";
                     $renderer->internallink($val["id"], $val["heading"]);
                     $renderer->doc .= "</div>";
                     $renderer->doc .= "</li>";
                 }
-            } elseif ($val["type"] == "ext_ns") {
-                    $renderer->doc .= "<li class='level" . $val["level"]." divert'>";
-                    $renderer->doc .= "<div class='li'>";
-                    $renderer->internallink($val["id"], $val["heading"]);
-                    $renderer->doc .= "</div>";
-                    $renderer->doc .= "</li>";
             } elseif ($val["type"] == "ns") {
                 if (count($val["sub"]) == 0) {
                     continue;
@@ -423,7 +418,10 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
                     $renderer->doc .= "<li class='closed'>";
                 }
                 $renderer->doc .= "<div class='li'>";
-                if (in_array($val["ns_id"], $sub_ns)) {
+                if (empty($val["id"])) {
+                    // no page exists for this namespace, render as plain text with no broken link
+                    $renderer->doc .= "<span class='ns_nolink' data-id='" . hsc($val["ns_id"]) . "'>" . hsc($val["heading"]) . "</span>";
+                } elseif (in_array($val["ns_id"], $sub_ns)) {
                     $renderer->doc .= "<span class='curid'>";
                     $renderer->internallink($val["id"], $val["heading"]);
                     $renderer->doc .= "</span>";

--- a/syntax.php
+++ b/syntax.php
@@ -397,7 +397,7 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
             $val["id"] = utf8_decodeFN($val["id"]);
             $val["heading"] = utf8_decodeFN($val["heading"]);
             if ($val["type"] == "pg" || $val["type"] == "ext_ns") {
-                if ($val["type"] == "ext_ns" || !$this->getConf("mergenspg") || ($val["id"] !== $parent_id && !@is_dir(substr(wikiFN($val["id"]), 0, -strlen(".txt"))))) {
+                if ($val["type"] == "ext_ns" || (!$this->getConf("mergenspg") || ($val["id"] !== $parent_id && !@is_dir(substr(wikiFN($val["id"]), 0, -strlen(".txt")))))) {
                     $divert = ($val["type"] == "ext_ns") ? " divert" : "";
                     $renderer->doc .= "<li class='level" . $val["level"] . $divert . "'>";
                     $renderer->doc .= "<div class='li'>";

--- a/syntax.php
+++ b/syntax.php
@@ -277,11 +277,11 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
                 $dir_id   = implode(":", array_filter(array($ns_acmenu, $file), "strlen"));
                 $start_id = implode(":", array_filter(array($ns_acmenu, $file, $conf["start"]), "strlen"));
                 if (page_exists($start_id)) {
-                    $id = $start_id;  // :acmenu:start exists → link to it
+                    $id = $start_id;    // :acmenu:start exists → link to it
                 } elseif (page_exists($dir_id)) {
-                    $id = $dir_id;    // :acmenu exists → link to it instead
+                    $id = $dir_id;      // :acmenu exists → link to it instead
                 } else {
-                    $id = "";         // neither exists → render as plain text, no broken link
+                    $id = "#ns_nolink"; // neither exists → render as anchor jump, no broken link
                 }
                 if ($conf["sneaky_index"] && auth_quickaclcheck($id) < AUTH_READ) {
                     continue;
@@ -423,10 +423,7 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
                     $renderer->doc .= "<li class='closed'>";
                 }
                 $renderer->doc .= "<div class='li'>";
-                if (empty($val["id"])) {
-                    // no page exists for this namespace, render as plain text with no broken link
-                    $renderer->doc .= "<span class='ns_nolink' data-id='" . hsc($val["ns_id"]) . "'>" . hsc($val["heading"]) . "</span>";
-                } elseif (in_array($val["ns_id"], $sub_ns)) {
+                if (in_array($val["ns_id"], $sub_ns)) {
                     $renderer->doc .= "<span class='curid'>";
                     $renderer->internallink($val["id"], $val["heading"]);
                     $renderer->doc .= "</span>";

--- a/syntax.php
+++ b/syntax.php
@@ -276,19 +276,19 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
                 // $start_id = start page id,     e.g. :acmenu:start (pages/acmenu/start.txt)
                 $dir_id   = implode(":", array_filter(array($ns_acmenu, $file), "strlen"));
                 $start_id = implode(":", array_filter(array($ns_acmenu, $file, $conf["start"]), "strlen"));
-                if (page_exists($start_id)) {
-                    $id = $start_id;  // :acmenu:start exists → link to it
-                } elseif (page_exists($dir_id)) {
-                    $id = $dir_id;    // :acmenu exists → link to it instead
+                if (page_exists($dir_id) && !page_exists($start_id)) {
+                    $id = $dir_id;   // :acmenu exists → link to it
                 } else {
-                    continue;         // neither exists → skip namespace entirely
+                    $id = $start_id; // link to :acmenu:start instead
                 }
                 if ($conf["sneaky_index"] && auth_quickaclcheck($id) < AUTH_READ) {
                     continue;
                 } else {
                     $heading = $file;
                     if (useheading("navigation")) {
-                        $heading = p_get_first_heading($id);
+                        if (page_exists($id)) {
+                            $heading = p_get_first_heading($id);
+                        }
                     }
                     if (file_exists($dir . "/" . $file . "/" . $conf["sidebar"] . ".txt")) {
                         // subnamespace with sidebar (external namespace) will not be scanned

--- a/syntax.php
+++ b/syntax.php
@@ -272,20 +272,23 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
                     }
                 }
             } else {
-                $dir_id = implode(":", array_filter(array($ns_acmenu, $file), "strlen"));
+                // $dir_id  = namespace page id,  e.g. :acmenu       (pages/acmenu.txt)
+                // $start_id = start page id,     e.g. :acmenu:start (pages/acmenu/start.txt)
+                $dir_id   = implode(":", array_filter(array($ns_acmenu, $file), "strlen"));
                 $start_id = implode(":", array_filter(array($ns_acmenu, $file, $conf["start"]), "strlen"));
-                $id = $start_id;
-                if ($this->getConf("mergenspg") && page_exists($dir_id) && !page_exists($start_id)) {
-                    $id = $dir_id;
+                if (page_exists($start_id)) {
+                    $id = $start_id;  // :acmenu:start exists → link to it
+                } elseif (page_exists($dir_id)) {
+                    $id = $dir_id;    // :acmenu exists → link to it instead
+                } else {
+                    continue;         // neither exists → skip namespace entirely
                 }
                 if ($conf["sneaky_index"] && auth_quickaclcheck($id) < AUTH_READ) {
                     continue;
                 } else {
                     $heading = $file;
                     if (useheading("navigation")) {
-                        if (page_exists($id)) {
-                            $heading = p_get_first_heading($id);
-                        }
+                        $heading = p_get_first_heading($id);
                     }
                     if (file_exists($dir . "/" . $file . "/" . $conf["sidebar"] . ".txt")) {
                         // subnamespace with sidebar (external namespace) will not be scanned
@@ -409,9 +412,9 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
                 if (count($val["sub"]) == 0) {
                     continue;
                 }
-                
+
                 $is_open = in_array($val["ns_id"], $sub_ns) || in_array($val["id"], $open_items) || in_array($val["ns_id"], $open_items);
-                
+
                 if ($is_open) {
                     $renderer->doc .= "<li class='open'>";
                 } else {

--- a/syntax.php
+++ b/syntax.php
@@ -281,7 +281,7 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
                 } elseif (page_exists($dir_id)) {
                     $id = $dir_id;    // :acmenu exists → link to it instead
                 } else {
-                    $id = "";         // no page exists: render as plain text, no link
+                    $id = "";         // neither exists → render as plain text, no broken link
                 }
                 if ($conf["sneaky_index"] && auth_quickaclcheck($id) < AUTH_READ) {
                     continue;
@@ -424,8 +424,8 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
                 }
                 $renderer->doc .= "<div class='li'>";
                 if (empty($val["id"])) {
-                    // no page exists for this namespace, render as plain text
-                    $renderer->doc .= "<span class='ns_nolink'>" . hsc($val["heading"]) . "</span>";
+                    // no page exists for this namespace, render as plain text with no broken link
+                    $renderer->doc .= "<span class='ns_nolink' data-id='" . hsc($val["ns_id"]) . "'>" . hsc($val["heading"]) . "</span>";
                 } elseif (in_array($val["ns_id"], $sub_ns)) {
                     $renderer->doc .= "<span class='curid'>";
                     $renderer->internallink($val["id"], $val["heading"]);

--- a/syntax.php
+++ b/syntax.php
@@ -276,10 +276,12 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
                 // $start_id = start page id,     e.g. :acmenu:start (pages/acmenu/start.txt)
                 $dir_id   = implode(":", array_filter(array($ns_acmenu, $file), "strlen"));
                 $start_id = implode(":", array_filter(array($ns_acmenu, $file, $conf["start"]), "strlen"));
-                if (page_exists($dir_id) && !page_exists($start_id)) {
-                    $id = $dir_id;   // :acmenu exists → link to it
+                if (page_exists($start_id)) {
+                    $id = $start_id;  // :acmenu:start exists → link to it
+                } elseif (page_exists($dir_id)) {
+                    $id = $dir_id;    // :acmenu exists → link to it instead
                 } else {
-                    $id = $start_id; // link to :acmenu:start instead
+                    $id = "";         // no page exists: render as plain text, no link
                 }
                 if ($conf["sneaky_index"] && auth_quickaclcheck($id) < AUTH_READ) {
                     continue;

--- a/syntax.php
+++ b/syntax.php
@@ -423,7 +423,10 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
                     $renderer->doc .= "<li class='closed'>";
                 }
                 $renderer->doc .= "<div class='li'>";
-                if (in_array($val["ns_id"], $sub_ns)) {
+                if (empty($val["id"])) {
+                    // no page exists for this namespace, render as plain text
+                    $renderer->doc .= "<span class='ns_nolink'>" . hsc($val["heading"]) . "</span>";
+                } elseif (in_array($val["ns_id"], $sub_ns)) {
                     $renderer->doc .= "<span class='curid'>";
                     $renderer->internallink($val["id"], $val["heading"]);
                     $renderer->doc .= "</span>";

--- a/syntax.php
+++ b/syntax.php
@@ -146,7 +146,7 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
         $renderer->doc .= "</span>";
         $renderer->doc .= "</div>";
         $renderer->doc .= "<ul class='idx'>";
-        $this->_print($renderer, $tree, $sub_ns, $open_items);
+        $this->_print($renderer, $tree, $sub_ns, $open_items, $base_id);
         $renderer->doc .= "</ul>";
         $renderer->doc .= "</li>";
         $renderer->doc .= "</ul>";
@@ -385,14 +385,14 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
      *      [i] => (str) "<ns_acmenu>:<ns-1>:...:<ns-i>"
      *      }
      */
-    private function _print($renderer, $tree, $sub_ns, $open_items)
+    private function _print($renderer, $tree, $sub_ns, $open_items, $parent_id = "")
     {
         global $conf;
         foreach ($tree as $key => $val) {
             $val["id"] = utf8_decodeFN($val["id"]);
             $val["heading"] = utf8_decodeFN($val["heading"]);
             if ($val["type"] == "pg") {
-                if (!$this->getConf("mergenspg") || !@is_dir(substr(wikiFN($val["id"]), 0, -strlen(".txt")))) {
+                if (!$this->getConf("mergenspg") || ($val["id"] !== $parent_id && !@is_dir(substr(wikiFN($val["id"]), 0, -strlen(".txt"))))) {
                     $renderer->doc .= "<li class='level" . $val["level"]."'>";
                     $renderer->doc .= "<div class='li'>";
                     $renderer->internallink($val["id"], $val["heading"]);
@@ -431,7 +431,7 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
                 } else {
                     $renderer->doc .= "<ul class='idx' style='display: none;'>";
                 }
-                $this->_print($renderer, $val["sub"], $sub_ns, $open_items);
+                $this->_print($renderer, $val["sub"], $sub_ns, $open_items, $val["id"]);
                 $renderer->doc .= "</ul>";
                 $renderer->doc .= "</li>";
             }

--- a/syntax.php
+++ b/syntax.php
@@ -272,16 +272,18 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
                     }
                 }
             } else {
-                $id = implode(":", array_filter(array($ns_acmenu, $file, $conf["start"]), "strlen"));
+                $dir_id = implode(":", array_filter(array($ns_acmenu, $file), "strlen"));
+                $start_id = implode(":", array_filter(array($ns_acmenu, $file, $conf["start"]), "strlen"));
+                $id = $start_id;
+                if ($this->getConf("mergenspg") && page_exists($dir_id) && !page_exists($start_id)) {
+                    $id = $dir_id;
+                }
                 if ($conf["sneaky_index"] && auth_quickaclcheck($id) < AUTH_READ) {
                     continue;
                 } else {
                     $heading = $file;
                     if (useheading("navigation")) {
                         if (page_exists($id)) {
-                            $heading = p_get_first_heading($id);
-                        } elseif (substr($id, -strlen(":" . $conf["start"])) == ":" . $conf["start"]) {
-                            $id = substr($id, 0, -strlen(":" . $conf["start"]));
                             $heading = p_get_first_heading($id);
                         }
                     }
@@ -295,9 +297,10 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
                     } else {
                         $tree[] = array("heading" => $heading,
                                         "id" => $id,
+                                        "ns_id" => $dir_id,
                                         "level" => $level,
                                         "type" => "ns",
-                                        "sub" => $this->_tree(implode(":", array_filter(array($ns_acmenu, $file), "strlen")), $level));
+                                        "sub" => $this->_tree($dir_id, $level));
                     }
                 }
             }
@@ -389,7 +392,7 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
             $val["id"] = utf8_decodeFN($val["id"]);
             $val["heading"] = utf8_decodeFN($val["heading"]);
             if ($val["type"] == "pg") {
-                if ($this->getConf("mergenspg") && !@is_dir(substr(wikiFN($val["id"]), 0, -strlen(".txt")))) {
+                if (!$this->getConf("mergenspg") || !@is_dir(substr(wikiFN($val["id"]), 0, -strlen(".txt")))) {
                     $renderer->doc .= "<li class='level" . $val["level"]."'>";
                     $renderer->doc .= "<div class='li'>";
                     $renderer->internallink($val["id"], $val["heading"]);
@@ -406,14 +409,16 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
                 if (count($val["sub"]) == 0) {
                     continue;
                 }
-                if (in_array($val["id"], $sub_ns)
-                    || in_array($val["id"], $open_items)) {
+                
+                $is_open = in_array($val["ns_id"], $sub_ns) || in_array($val["id"], $open_items) || in_array($val["ns_id"], $open_items);
+                
+                if ($is_open) {
                     $renderer->doc .= "<li class='open'>";
                 } else {
                     $renderer->doc .= "<li class='closed'>";
                 }
                 $renderer->doc .= "<div class='li'>";
-                if (in_array($val["id"], $sub_ns)) {
+                if (in_array($val["ns_id"], $sub_ns)) {
                     $renderer->doc .= "<span class='curid'>";
                     $renderer->internallink($val["id"], $val["heading"]);
                     $renderer->doc .= "</span>";
@@ -421,11 +426,10 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
                     $renderer->internallink($val["id"], $val["heading"]);
                 }
                 $renderer->doc .= "</div>";
-                if (in_array($val["id"], $sub_ns)
-                    || in_array($val["id"], $open_items)) {
+                if ($is_open) {
                     $renderer->doc .= "<ul class='idx'>";
                 } else {
-                    $renderer->doc .= "<ul class='idx' style='display: none'>";
+                    $renderer->doc .= "<ul class='idx' style='display: none;'>";
                 }
                 $this->_print($renderer, $val["sub"], $sub_ns, $open_items);
                 $renderer->doc .= "</ul>";


### PR DESCRIPTION
Same as PR #13 with the following changes:
This PR fixes the following:
- Useheading for "start" pages
- Fix useheading parse for namespaces that do not contains the ":start" pages.
- Sorting of menus when using "useheading" DokuWiki directive to be as documented on DokuWiki plugin page using "usort" PHP func Also merges the page with the namespace if it contains subnamespaces (through "is_dir" PHP func)