### PR TITLE
Fix DokuWiki indexer (indexer.php)

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -253,7 +253,7 @@ class syntax_plugin_acmenu extends DokuWiki_Syntax_Plugin
         global $conf;
         $tree = array();
         $level = $level + 1;
-        $dir = $conf["savedir"] ."/pages/" . str_replace(":", "/", $ns_acmenu);
+        $dir = init_path($conf["savedir"]) ."/pages/" . str_replace(":", "/", $ns_acmenu);
         $files = array_diff(scandir($dir), array("..", "."));
         foreach ($files as $file) {
             if (is_file($dir . "/" . $file)) {


### PR DESCRIPTION
Hello,
When running the built-in command line tool to reindex DokuWiki through command line from the ``/bin`` directory of DokuWiki instead of it's root path ``/``, the AcMenu breaks the DokuWiki indexer:

```
su dokuwiki
cd /var/www/dokuwiki/bin
php indexer.php -c
sidebar... PHP Warning:  scandir(./data/pages/): Failed to open directory: No such file or directory in /var/www/dokuwiki/lib/plugins/acmenu/syntax.php on line 257
PHP Warning:  scandir(): (errno 0): Success in /var/www/dokuwiki/lib/plugins/acmenu/syntax.php on line 257
�� TypeError: array_diff(): Argument #1 ($array) must be of type array, bool given in /var/www/dok
```

It happens because ``conf["savedir"]`` DokuWiki setting assumes it's location being relative from DokuWiki root path (``./data``), so as ``/bin/data`` directory doesn't exist, it fails. This PR adds the ``init_path`` to parse the ``conf["savedir"]`` DokuWiki setting so the DokuWiki indexer finds the DokuWiki ``data`` path as expected.